### PR TITLE
Added funtionality to moddodo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This tool is intended be run with python3.
 - `--steamcmd PATH` - (optional) directory of the SteamCMD install you wish to use, if not under `~/steam/Steam`
 - `--updatemods` - (optional) - update all mods currently installed on the server
 - `--deletecache` - (optional) - deletes previously downloaded mods in SteamCMD for multi-server environments
-- `--nodownload` - (optional) - prevents the execution of steamcmd to download/update the mods in the local directory, also ignores steamcmd parameter
+- `--nodownload` - (optional) - prevents the execution of steamcmd to download/update the mods in the local directory, also ignores steamcmd parameter. This option allows the download the mods in a multi ark server environment once and then use a script and this tool to update the ark servers consecutively.
 
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ This tool is intended be run with python3.
 ### Commandline Arguments
 
 - `--serverdir PATH` - (optional) - home directory of the server (containing the `/ShooterGame` folder)
+- `--localmoddir PATH` - (optional) - local directory for steam to download mods (usually ends with `/Steam/steamapps/workshop/content/346110`)
 - `--modids ID [ID...]` - space-separated list of steam IDs of the mod you wish to 
 - `--steamcmd PATH` - (optional) directory of the SteamCMD install you wish to use, if not under `~/steam/Steam`
 - `--updatemods` - (optional) - update all mods currently installed on the server
 - `--deletecache` - (optional) - deletes previously downloaded mods in SteamCMD for multi-server environments
+- `--nodownload` - (optional) - prevents the execution of steamcmd to download/update the mods in the local directory, also ignores steamcmd parameter
+
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This tool is intended be run with python3.
 
 - `--serverdir PATH` - (optional) - home directory of the server (containing the `/ShooterGame` folder)
 - `--localmoddir PATH` - (optional) - local directory for steam to download mods (usually ends with `/Steam/steamapps/workshop/content/346110`)
-- `--modids ID [ID...]` - space-separated list of steam IDs of the mod you wish to 
+- `--modids ID [ID...]` - space-separated list of steam IDs of the mod you wish to install or update
 - `--steamcmd PATH` - (optional) directory of the SteamCMD install you wish to use, if not under `~/steam/Steam`
 - `--updatemods` - (optional) - update all mods currently installed on the server
 - `--deletecache` - (optional) - deletes previously downloaded mods in SteamCMD for multi-server environments

--- a/arkit.py
+++ b/arkit.py
@@ -110,15 +110,18 @@ def unpack(src, dst):
 
                     #Verify the size of the data is consistent with the archives index
                     if len(uncompressed_data) == uncompressed:
+                      #Write the extracted data to disk
                       f_out.write(uncompressed_data)
                       read_data += 1
 
                       #Verify there is only one partial chunk
                       if len(uncompressed_data) != size_unpacked_chunk and read_data != len(compression_index):
+                            f_out.close()
                             msg = "Index contains more than one partial chunk: was {} when the full chunk size is {}, chunk {}/{}".format(len(uncompressed_data), size_unpacked_chunk, read_data, len(compression_index))
                             logging.critical(msg)
                             raise CorruptUnpackException(msg)
                     else:
+                        f_out.close()
                         msg = "Uncompressed chunk size is not the same as in the index: was {} but should be {}.".format(len(uncompressed_data), uncompressed)
                         logging.critical(msg)
                         raise CorruptUnpackException(msg)
@@ -133,6 +136,4 @@ def unpack(src, dst):
             logging.critical(msg)
             raise SignatureUnpackException(msg)
 
-    #Write the extracted data to disk
-    
     logging.info("Archive has been extracted.")

--- a/moddodo.py
+++ b/moddodo.py
@@ -365,8 +365,8 @@ def main():
     parser.add_argument("--localmoddir", default=".", dest="localmoddir", help="local directory where steam downloads mods (usually ~/.local/share/Steam/steamapps/workshop/content/346110")
     parser.add_argument("--modids", nargs="+", default=None, dest="modids", help="space-separated list of IDs of mods to install")
     parser.add_argument("--steamcmd", default="/usr/games", dest="steamcmd", help="path to SteamCMD, default: /usr/games")
-    parser.add_argument("--updatemods", "-u", default=False, action="store_true", dest="forceupdate", help="update existing mods")
-    parser.add_argument("--force", "-f", default=False, action="store_true", dest="updatemods", help="update existing mods")
+    parser.add_argument("--updatemods", "-u", default=False, action="store_true", dest="updatemods", help="update existing mods")
+    parser.add_argument("--force", "-f", default=False, action="store_true", dest="forceupdate", help="force update of mods on -u (also when not newer)")
     parser.add_argument("--deletecache", "-d", default=False, action="store_true", dest="deletecache", help="Delete SteamCMD cache, if used in multi-server environment")
     parser.add_argument("--nodownload", "-nd", default=False, action="store_true", dest="nodownload", help="Skip download via steamcmd")
 

--- a/moddodo.py
+++ b/moddodo.py
@@ -64,9 +64,15 @@ class ModDodo:
         print("")
 
         for modid in modids:
-            steammodftime=os.path.getmtime(os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR, "mod.info"))
-            arkmodftime=os.path.getmtime(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY, modid, "mod.info"))
-            if mod_update and steammodftime <= arkmodftime and not force_update:
+            if os.path.isfile(os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR, "mod.info")):
+                steammodftime=os.path.getmtime(os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR, "mod.info"))
+            else:
+                steammodftime=1
+            if os.path.isfile(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY, modid, "mod.info")):
+                arkmodftime=os.path.getmtime(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY, modid, "mod.info"))
+            else:
+                arkmmodftime=0
+            if mod_update and steammodftime <= arkmodftime and force_update:
                 continue
             self.workdir = tempfile.mkdtemp()
             if self.extract_mod(modid):

--- a/moddodo.py
+++ b/moddodo.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 from collections import OrderedDict
 import struct
+import ctypes
 
 SERVER_MOD_DIRECTORY = "ShooterGame/Content/Mods"
 
@@ -202,7 +203,7 @@ class ModDodo:
         with open(os.path.join(self.workdir, modid+".mod"), "w+b") as f:
 
             modid = int(modid)
-            f.write(struct.pack('ixxxx', modid))  # Needs 4 pad bits
+            f.write(struct.pack('Ixxxx', modid))  # Needs 4 pad bits
             self.write_ue4_string("ModName", f)
             self.write_ue4_string("", f)
 

--- a/moddodo.py
+++ b/moddodo.py
@@ -64,11 +64,11 @@ class ModDodo:
         print("")
 
         for modid in modids:
-            self.workdir = tempfile.mkdtemp()
             steammodftime=os.path.getmtime(os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR, "mod.info"))
             arkmodftime=os.path.getmtime(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY, modid, "mod.info"))
             if mod_upddate and steammodftime <= arkmodftime and not force_update:
-               continue
+                continue
+            self.workdir = tempfile.mkdtemp()
             if self.extract_mod(modid):
                 if self.create_mod_file(modid):
                     if self.move_mod(modid):

--- a/moddodo.py
+++ b/moddodo.py
@@ -237,11 +237,11 @@ class ModDodo:
             shutil.move(target_mod_file, target_mod_file_inst)
 
             shutil.copystat(target_mod_file_info, target_mod_file_inst)
-            os.chmod(target_mod_file_inst, 0o664)
+            os.chmod(target_mod_file_inst, 0o600)
             target_mod_file = os.path.join(ark_mod_directory, str(modid), "modmeta.info")
-            os.chmod(target_mod_file, 0o664)
+            os.chmod(target_mod_file, 0o660)
             target_mod_file = os.path.join(ark_mod_directory, str(modid), "mod.info")
-            os.chmod(target_mod_file, 0o664)
+            os.chmod(target_mod_file, 0o660)
 
             return True
         except Exception as e:

--- a/moddodo.py
+++ b/moddodo.py
@@ -116,7 +116,7 @@ class ModDodo:
             return
         for current_dir, directories, files in os.walk(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY)):
             for directory in directories:
-                # AFAIK these are updated by Ark itself, maybe only with -automanagedmods
+                # AFAIK these are updated by Ark itself, maybe only with -automanagedmods, 834585900 and 916417001 are maps
                 if directory.isdigit() and directory not in ["111111111", "834585900", "916417001"]:
                     modids.append(directory)
             break
@@ -217,6 +217,9 @@ class ModDodo:
         ark_mod_directory = os.path.join(self.server_directory, SERVER_MOD_DIRECTORY)
         target_mod_directory = os.path.join(ark_mod_directory, str(modid))
         source_mod_directory = os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR)
+        target_mod_file = os.path.join(ark_mod_directory, str(modid), ".mod")
+        target_mod_file_info = os.path.join(ark_mod_directory, str(modid), "mod.info")
+        target_mod_file_inst = os.path.join(ark_mod_directory, str(modid)+".mod")
 
         try:
             if not os.path.isdir(ark_mod_directory):
@@ -226,6 +229,20 @@ class ModDodo:
                 shutil.rmtree(target_mod_directory)
 
             shutil.copytree(source_mod_directory, target_mod_directory)
+
+            """
+            Move binary .mod file from MOD directory to the level above
+            """
+
+            shutil.move(target_mod_file, target_mod_file_inst)
+
+            shutil.copystat(target_mod_file_info, target_mod_file_inst)
+            os.chmod(target_mod_file_inst, 0o664)
+            target_mod_file = os.path.join(ark_mod_directory, str(modid), "modmeta.info")
+            os.chmod(target_mod_file, 0o664)
+            target_mod_file = os.path.join(ark_mod_directory, str(modid), "mod.info")
+            os.chmod(target_mod_file, 0o664)
+
             return True
         except Exception as e:
             print_error("Encountered unexpected exception during move operation from " + source_mod_directory + " to " + target_mod_directory + ":\n"

--- a/moddodo.py
+++ b/moddodo.py
@@ -9,7 +9,6 @@ import subprocess
 import tempfile
 from collections import OrderedDict
 import struct
-import ctypes
 
 SERVER_MOD_DIRECTORY = "ShooterGame/Content/Mods"
 

--- a/moddodo.py
+++ b/moddodo.py
@@ -66,7 +66,7 @@ class ModDodo:
         for modid in modids:
             steammodftime=os.path.getmtime(os.path.join(self.download_mod_directory, modid, WINDOWS_NOEDITOR, "mod.info"))
             arkmodftime=os.path.getmtime(os.path.join(self.server_directory, SERVER_MOD_DIRECTORY, modid, "mod.info"))
-            if mod_upddate and steammodftime <= arkmodftime and not force_update:
+            if mod_update and steammodftime <= arkmodftime and not force_update:
                 continue
             self.workdir = tempfile.mkdtemp()
             if self.extract_mod(modid):


### PR DESCRIPTION
Working with the script in a multi ark server environment and writing my local script to handle the mod updates, I noticed several points I try to improve with this:
1. for mod updates, moddodo.py uses the server mod directory to create the mod list, downloads the whole set and installs them all, regardless whether they were updated or not, in a multi server environment doing this for every server (resulting in a total update time of 1h). Moving the mod download into my own script, I can aggregate all mod ids and make a single call to steamcmd to download the mods to the local directory in the users home. As I do in this case not want moddodo.py to do any downloads, I added a parameter (-nodownlod -nd) to disable the download completely. In a future step, the time stamp of the mod.info in the local mod download directory can be compared with the mod.info in the server mod directory and the mod installation can be skipped as long as the mod.info in the local mod download directory is not newer than the one in the server download directory. When using this parameter, the check for the steamcmd is omitted as steamcmd will not be used at all.
2. moddodo.py determined the local download directory by combining the steamcmd directory with the usual download directory for Ark mods. In my case, mods are stored in /.local/share/Steam/steamapps/workshop/content/346110 in the home directory of the user calling steamcmd. So I changed this. To allow other setups, a parameter --localmoddir was added to set a different path. 
3. moddodo.py did not check the existance of the mod directory in the local mod download directory. This was added and an error is thrown if it is missing.
4. Other global path variables were set to match the current linux environment.